### PR TITLE
Usable python3/pygobject/gtk3 menu editor 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,10 @@ endif
 PKG_CONFIG ?= pkg-config
 
 # checking for python
-PYTHONBIN?=$(shell which python$(shell $(PKG_CONFIG) --modversion python-2.7 2> /dev/null))
-PYTHONBIN?=$(shell which python2.6)
-PYTHONBIN?=$(shell which python2)
+PYTHONBIN?=$(shell which python)
 
 ifeq ("$(PYTHONBIN)", "")
-$(error Python not found. Version >= 2.7 or 2.6 is required.)
+$(error Python not found.)
 endif
 
 # Set up compile flags

--- a/new-editor/cb-editor
+++ b/new-editor/cb-editor
@@ -267,8 +267,8 @@ class CBEditor(Gtk.Window):
 				dialog.destroy()
 			except etree.XMLSyntaxError as e:
 				message = Gtk.MessageDialog(parent=self, flags=0, 
-				    type=Gtk.MessageType.ERROR, 
-				    buttons=Gtk.ButtonsType.OK, message_format=None)
+					type=Gtk.MessageType.ERROR,
+					buttons=Gtk.ButtonsType.OK, message_format=None)
 				msg = ("{}\n\nClick the gear icon in the dialog to check"
 				" pipe output.").format(e.msg)
 				message.set_markup(msg)
@@ -444,6 +444,7 @@ class CBEditor(Gtk.Window):
 		dialog.set_version("1.1.6")
 		dialog.set_authors(["ShadowKyogre","crdlb"])
 		dialog.set_comments("A specialized editor for Compiz Boxmenu's menu files")
+		dialog.set_logo_icon_name("help-about")
 		dialog.run()
 		dialog.destroy()
 
@@ -491,7 +492,7 @@ if __name__ == '__main__':
 	except IOError:
 		allnotcache=True
 	elementlist = ['Launcher', 'Menu', 'Separator', 'Windows List',
-	               'Desktops List','Viewports List', 'Recent Documents', 
-				   'Reload', 'Menu File']
+				'Desktops List','Viewports List', 'Recent Documents',
+				'Reload', 'Menu File']
 	CBEditor()
 	Gtk.main()

--- a/new-editor/cb-editor
+++ b/new-editor/cb-editor
@@ -442,7 +442,7 @@ class CBEditor(Gtk.Window):
 		dialog=Gtk.AboutDialog()
 		dialog.set_name("Compiz Boxmenu Editor")
 		dialog.set_version("1.1.6")
-		dialog.set_authors(["ShadowKyogre","crdlb"])
+		dialog.set_authors(["ShadowKyogre","mazes_80","crdlb"])
 		dialog.set_comments("A specialized editor for Compiz Boxmenu's menu files")
 		dialog.set_logo_icon_name("help-about")
 		dialog.run()

--- a/new-editor/cb-editor
+++ b/new-editor/cb-editor
@@ -35,8 +35,6 @@ class CBEditor(Gtk.Window):
 		new_button.connect('clicked', self.new_item_dialog)
 		new_button.set_tooltip_text("Create a new menu file or menu item")
 
-		#edit_button = Gtk.ToolButton(Gtk.STOCK_EDIT) # necessary?
-
 		save_button = Gtk.MenuToolButton(Gtk.STOCK_SAVE)
 		save_button.set_menu(self.make_save_menu())
 		save_button.connect('clicked', self.save_one)
@@ -55,9 +53,6 @@ class CBEditor(Gtk.Window):
 		reload_button.connect('clicked', self.reload_menu)
 		reload_button.set_tooltip_text('Reload the daemon')
 
-		#settings_button = Gtk.ToolButton(Gtk.STOCK_PREFERENCES)
-		#settings_button.connect('clicked', self.show_settings)
-
 		about_button = Gtk.ToolButton(Gtk.STOCK_ABOUT)
 		about_button.connect('clicked', self.show_about_dialog)
 		about_button.set_tooltip_text('Show some information about this program')
@@ -69,16 +64,12 @@ class CBEditor(Gtk.Window):
 		sep2.set_draw(False)
 		sep2.set_expand(True)
 		toolbar.insert(new_button, 0)
-		#toolbar.insert(edit_button, 1)
 		toolbar.insert(save_button, 1)
 		toolbar.insert(generate_button, 2)
 		toolbar.insert(delete_button, 3)
 		toolbar.insert(sep, 4)
-		#toolbar.insert(undo_button, 6)
-		#toolbar.insert(redo_button, 7)
 		toolbar.insert(sep2, 5)
 		toolbar.insert(reload_button, 6)
-		#toolbar.insert(settings_button, 8)
 		toolbar.insert(about_button, 7)
 
 		self.vbox.pack_start(toolbar, expand=False, fill=True, padding=0)
@@ -100,13 +91,13 @@ class CBEditor(Gtk.Window):
 		cell = Gtk.CellRendererToggle()
 		cell.set_activatable(True)
 		cell.connect('toggled', self.update_cache)
-		cached.pack_start(cell, expand=True) #, True, 0)
+		cached.pack_start(cell, expand=True)
 		cached.add_attribute(cell, "active", 0)
 
 		name = Gtk.TreeViewColumn('Menu')
 		listview.append_column(name)
 		cell = Gtk.CellRendererText()
-		name.pack_start(cell, expand=True) #, True, 0)
+		name.pack_start(cell, expand=True)
 		name.add_attribute(cell,"text", 1)
 
 		self.tabs=Gtk.Notebook()
@@ -117,10 +108,8 @@ class CBEditor(Gtk.Window):
 		self.tabs.set_show_tabs(True)
 		self.tabs.set_tab_pos(Gtk.PositionType.TOP)
 
-		#self.hbox_item=Gtk.HBox(False, 2)
 
 		self.vbox.pack_start(hbox_main, expand=True, fill=True, padding=0)
-		#self.vbox.pack_end(self.hbox_item, expand=False, fill=False)
 		self.add(self.vbox)
 		self.show_all()
 

--- a/new-editor/cbmenu.py
+++ b/new-editor/cbmenu.py
@@ -164,15 +164,16 @@ class MenuFile(Gtk.ScrolledWindow):
 		model, iter = treeselection.get_selected()
 		data = model.get_string_from_iter(iter)
 
-		selection.set(selection.get_target(), 8, data)
+		selection.set(selection.get_target(), 8, data.encode())
 
 	def on_drag_data_received(self, treeview, context, x, y, selection,
 								info, etime):
 		model = treeview.get_model()
-		data = selection.get_data()
+		data = selection.get_data().decode()
 
 		drop_info = treeview.get_dest_row_at_pos(x, y)
-		if selection.get_data_type() == 'deskmenu-element':
+		# todo compare identical class
+		if selection.get_data_type().name() == 'deskmenu-element':
 			source = model[data][0]
 			if drop_info:
 				path, position = drop_info
@@ -183,7 +184,7 @@ class MenuFile(Gtk.ScrolledWindow):
 					return
 
 				dest = model[path][0]
-				if context.action == Gdk.DragAction.MOVE:
+				if context.get_selected_action() == Gdk.DragAction.MOVE:
 					source.node.getparent().remove(source.node)
 
 				if dest.node.tag == 'menu' and position in (Gtk.TreeViewDropPosition.INTO_OR_BEFORE,
@@ -205,10 +206,10 @@ class MenuFile(Gtk.ScrolledWindow):
 					while citer is not None:
 						model.append(fiter, row=(model[citer][0],))
 						citer = model.iter_next(citer)
-				if context.action == Gdk.DragAction.MOVE:
+				if context.get_selected_action() == Gdk.DragAction.MOVE:
 					context.finish(True, True, etime)
 
-		elif selection.get_data_type() == 'text/uri-list':
+		elif selection.get_data_type().name() == 'text/uri-list':
 			print(selection.data, drop_info)
 			#uri = selection.data.replace('file:///', '/').replace("%20"," ").replace("\x00","").strip()
 			uris = selection.data.replace('file:///', '/').strip('\r\n\x00').split()
@@ -252,7 +253,7 @@ class MenuFile(Gtk.ScrolledWindow):
 							fiter = model.insert_after(None, diter, row=(launcher,))
 							diter = fiter
 						i+=1
-				if context.action == Gdk.DragAction.MOVE:
+				if context.get_selected_action() == Gdk.DragAction.MOVE:
 					context.finish(True, True, etime)
 			else:
 				for launcher in launchers:

--- a/new-editor/cbmenu.py
+++ b/new-editor/cbmenu.py
@@ -164,15 +164,15 @@ class MenuFile(Gtk.ScrolledWindow):
 		model, iter = treeselection.get_selected()
 		data = model.get_string_from_iter(iter)
 
-		selection.set(selection.target, 8, data)
+		selection.set(selection.get_target(), 8, data)
 
 	def on_drag_data_received(self, treeview, context, x, y, selection,
 								info, etime):
 		model = treeview.get_model()
-		data = selection.data
+		data = selection.get_data()
 
 		drop_info = treeview.get_dest_row_at_pos(x, y)
-		if selection.type == 'deskmenu-element':
+		if selection.get_data_type() == 'deskmenu-element':
 			source = model[data][0]
 			if drop_info:
 				path, position = drop_info
@@ -208,7 +208,7 @@ class MenuFile(Gtk.ScrolledWindow):
 				if context.action == Gdk.DragAction.MOVE:
 					context.finish(True, True, etime)
 
-		elif selection.type == 'text/uri-list':
+		elif selection.get_data_type() == 'text/uri-list':
 			print(selection.data, drop_info)
 			#uri = selection.data.replace('file:///', '/').replace("%20"," ").replace("\x00","").strip()
 			uris = selection.data.replace('file:///', '/').strip('\r\n\x00').split()

--- a/new-editor/cbmenu.py
+++ b/new-editor/cbmenu.py
@@ -285,7 +285,7 @@ class MenuFile(Gtk.ScrolledWindow):
 				path, col, cellx, celly = pthinfo
 				treeview.grab_focus()
 				treeview.set_cursor(path, col, 0)
-				self.popup.popup(None, None, None, event.button, event.time)
+				self.popup.popup(None, None, None, None, event.button, event.time)
 			return 1
 
 	def get_icon_mode(self):

--- a/new-editor/cbmenu.py
+++ b/new-editor/cbmenu.py
@@ -8,14 +8,6 @@ import configparser
 from lxml import etree
 from cb_itemtypes import *
 
-#test lines:
-#import cbmenu,cb_itemtypes
-#from gi.repository import Gtk
-#blah=cbmenu.MenuFile("/home/shadowkyogre/.config/compiz/boxmenu/menu.xml")
-#blurg=Gtk.Window()
-#blurg.add(blah)
-#blurg.show_all()
-
 class MenuFile(Gtk.ScrolledWindow):
 
 	def __init__(self,filename):
@@ -41,15 +33,13 @@ class MenuFile(Gtk.ScrolledWindow):
 		name.set_cell_data_func(cell, self.get_icon)
 
 		cell = Gtk.CellRendererText()
-		name.pack_start(cell, expand=True) #, True, 0)
+		name.pack_start(cell, expand=True)
 		name.set_cell_data_func(cell, self.get_name)
 
 		self.treeview.append_column(name)
 		self.add(self.treeview)
 		targets = [
 			('deskmenu-element', Gtk.TargetFlags.SAME_WIDGET, 0),
-			#('deskmenu-element', Gtk.TargetFlags.SAME_APP, 0),
-			#('deskmenu-element', Gtk.TREE_VIEW_ITEM, 0),
 			('text/uri-list', 0, 1),
 		]
 		self.treeview.enable_model_drag_source(Gdk.ModifierType.BUTTON1_MASK, targets, Gdk.DragAction.DEFAULT|Gdk.DragAction.MOVE)
@@ -172,7 +162,6 @@ class MenuFile(Gtk.ScrolledWindow):
 		data = selection.get_data().decode()
 
 		drop_info = treeview.get_dest_row_at_pos(x, y)
-		# todo compare identical class
 		if selection.get_data_type().name() == 'deskmenu-element':
 			source = model[data][0]
 			if drop_info:
@@ -211,7 +200,6 @@ class MenuFile(Gtk.ScrolledWindow):
 
 		elif selection.get_data_type().name() == 'text/uri-list':
 			print(selection.data, drop_info)
-			#uri = selection.data.replace('file:///', '/').replace("%20"," ").replace("\x00","").strip()
 			uris = selection.data.replace('file:///', '/').strip('\r\n\x00').split()
 			launchers = []
 			for uri in uris:
@@ -235,7 +223,6 @@ class MenuFile(Gtk.ScrolledWindow):
 				path, position = drop_info
 				dest = model[path][0]
 				diter = model.get_iter(path)
-				#print(dest.node, dest.node.getroot())
 				if dest.node.tag == 'menu' and position in (Gtk.TreeViewDropPosition.INTO_OR_BEFORE,
 					Gtk.TreeViewDropPosition.INTO_OR_AFTER):
 					for launcher in launchers:

--- a/new-editor/cbutil.py
+++ b/new-editor/cbutil.py
@@ -165,12 +165,13 @@ class IconSelector(Gtk.HBox):
 
 			if mode == "File path":
 				size=Gtk.icon_size_lookup(Gtk.IconSize.LARGE_TOOLBAR)[0]
-				try:
-					pixbuf=GdkPixbuf.Pixbuf.new_from_file_at_size(os.path.expanduser(self.text), size, size)
-					self.image.set_from_pixbuf(pixbuf)
-				except GLib.GError:
-					self.image.set_from_pixbuf(None)
-					print("Couldn't set icon from file: %s" %(self.text))
+				if self.text != None:
+					try:
+						pixbuf=GdkPixbuf.Pixbuf.new_from_file_at_size(os.path.expanduser(self.text), size, size)
+						self.image.set_from_pixbuf(pixbuf)
+					except GLib.GError:
+						self.image.set_from_pixbuf(None)
+						print("Couldn't set icon from file: %s" %(self.text))
 			else:
 				self.image.set_from_icon_name(self.text,Gtk.IconSize.LARGE_TOOLBAR)
 			self.button.set_tooltip_text(self.text)
@@ -233,8 +234,8 @@ def set_up():
 	GObject.type_register(CommandText)
 	GObject.type_register(IconSelector)
 
-	GObject.signal_new("text-changed", CommandText, GObject.SignalFlags.RUN_FIRST,  None, (GObject.TYPE_STRING,))
-	GObject.signal_new("mode-changed", CommandText, GObject.SignalFlags.RUN_FIRST,  None, (GObject.TYPE_STRING,))
+	GObject.signal_new("text-changed", CommandText, GObject.SignalFlags.RUN_FIRST,	None, (GObject.TYPE_STRING,))
+	GObject.signal_new("mode-changed", CommandText, GObject.SignalFlags.RUN_FIRST,	None, (GObject.TYPE_STRING,))
 
 	GObject.signal_new("image-changed", IconSelector, GObject.SignalFlags.RUN_FIRST,  None, (GObject.TYPE_STRING,))
 	GObject.signal_new("text-changed", IconSelector, GObject.SignalFlags.RUN_FIRST,  None, (GObject.TYPE_STRING,))

--- a/new-editor/cbutil.py
+++ b/new-editor/cbutil.py
@@ -48,7 +48,7 @@ class CommandText(Gtk.HBox):
 			self.entry.props.text=text
 
 			self.button=Gtk.Button()
-			image=Gtk.Image.new_from_icon_name("gtk-execute",Gtk.IconSize.LARGE_TOOLBAR)
+			image=Gtk.Image.new_from_icon_name("system-run",Gtk.IconSize.LARGE_TOOLBAR)
 			self.button.set_image(image)
 			#known bug
 			self.button.set_tooltip_markup("See the output this command generates")

--- a/new-editor/cbutil.py
+++ b/new-editor/cbutil.py
@@ -172,6 +172,8 @@ class IconSelector(Gtk.HBox):
 					except GLib.GError:
 						self.image.set_from_pixbuf(None)
 						print("Couldn't set icon from file: %s" %(self.text))
+				else:
+					self.image.set_from_pixbuf(None)
 			else:
 				self.image.set_from_icon_name(self.text,Gtk.IconSize.LARGE_TOOLBAR)
 			self.button.set_tooltip_text(self.text)

--- a/new-editor/cbutil.py
+++ b/new-editor/cbutil.py
@@ -23,20 +23,7 @@ class TabButton(Gtk.HBox):
 		self.btn.add(close_image)
 		self.pack_start(self.btn, expand=False, fill=False, padding=0)
 
-		#this reduces the size of the button
-		#style = Gtk.RcStyle()
-		#style.xthickness = 0
-		#style.ythickness = 0
-		#self.btn.modify_style(style)
-
 		self.show_all()
-
-#test code
-#from cbutil import *
-#from gi.repository import Gtk
-#d=Gtk.Dialog()
-#d.vbox.add(CommandText())
-#d.run()
 
 class CommandText(Gtk.HBox):
 	def __init__(self, label_text="Name", mode="Normal", text="", alternate_mode="Execute"):
@@ -50,7 +37,6 @@ class CommandText(Gtk.HBox):
 			self.button=Gtk.Button()
 			image=Gtk.Image.new_from_icon_name("system-run",Gtk.IconSize.LARGE_TOOLBAR)
 			self.button.set_image(image)
-			#known bug
 			self.button.set_tooltip_markup("See the output this command generates")
 
 			self.combobox=Gtk.ComboBoxText()
@@ -133,13 +119,6 @@ class CommandText(Gtk.HBox):
 		dialog.show_all()
 		dialog.run()
 		dialog.destroy()
-
-#test code
-#from cbutil import *
-#from gi.repository import Gtk
-#d=Gtk.Dialog()
-#d.vbox.add(IconSelector())
-#d.run()
 
 class IconSelector(Gtk.HBox):
 	def __init__(self, label_text="Icon", mode="Normal", text=""):

--- a/new-editor/pyicon_browser.py
+++ b/new-editor/pyicon_browser.py
@@ -3,17 +3,13 @@ from gi.repository import GdkPixbuf
 from gi.repository import GObject
 import re
 from gi.repository import GLib
-#from GLib import GError
 from sys import stderr
-
-#http://developer.gnome.org/pygtk/2.22/class-gtkicontheme.html#method-gtkicontheme--list-contexts
 
 class IcoBrowse(Gtk.Dialog):
 	def __init__(self, message="", default_text='', modal=True):
 		GObject.GObject.__init__(self)
 		self.add_buttons(Gtk.STOCK_CANCEL, Gtk.ResponseType.CLOSE,
 		      Gtk.STOCK_OK, Gtk.ResponseType.ACCEPT)
-		#self.set_title("Icon search")
 		if modal:
 			self.set_modal(True)
 		self.set_border_width(5)
@@ -22,9 +18,6 @@ class IcoBrowse(Gtk.Dialog):
 		self.combobox.set_size_request(200, 20)
 		hbox=Gtk.HBox(False,2)
 		
-		#format: actual icon, name, context
-		#self.model=Gtk.ListStore(GdkPixbuf.Pixbuf, GObject.TYPE_STRING, GObject.TYPE_STRING)
-		#self.modelfilter=self.model.filter_new()
 		self.modelfilter=ICON_STORE.filter_new()
 		self.iconview=Gtk.IconView()
 		self.iconview.set_model(self.modelfilter)
@@ -110,7 +103,6 @@ def set_up():
 		current=defaulttheme.list_icons(context=c)
 		catted_icons=catted_icons.union(set(current))
 		print("Found {} icons in {}".format(len(current),c))
-		#self.combobox.append_text(c)
 		for i in current:
 			try:
 				ICON_STORE.append([defaulttheme.load_icon(i, 32,


### PR DESCRIPTION
Drag'n'drop works (mostly by using getters instead of direct access)
makefile: get rid of python2_7 only wrapper
Reworked icons and desktop files.

It seems totally usable now but icon treeview still emits warnings

P.S.:
PR #7 was a WIP some things don't work and the UI crashes a lot.
PR #9 was closed by a commit totally unrelated to the menu editor.